### PR TITLE
Compatability fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.blend*
 Text.py
 misc
+.idea

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Node sharer (Beta)
+# Node sharer v0.2.0
 
 Easily share procedural materials and shader node setups as text!
 
@@ -9,13 +9,15 @@ Easily share procedural materials and shader node setups as text!
 [Watch it in high quality](https://giant.gfycat.com/LimpingUnequaledChameleon.webm)
 
 ## Installation
-1. Download the zip-file from the green "Code" button near the top of the page or by clicking [here](https://github.com/wildiness/NodeSharer/archive/master.zip).
+1. Download the zip-file from the green "Code" button near the top of the page or by clicking [here](https://github.com/wildiness/NodeSharer/archive/master.zip). Or get it from the releases to the right.
 2. In Blender, go to Edit > Preferences > Add-ons
 3. Choose "Install..." and select the just downloaded zip-file.
 4. Node sharer should appear in the list. Check the checkbox to activate it.
 5. Copy the text string below then, in Blender, go to the shading tab, in the shader editor press "Node" then scroll to the top of the list and select Paste material!
 
 NS0B2900!eNqtVk1vozAQ/SuVz06EDeSDW7NNo0hJdtVuV12tKuQEJ7FEIAKT7ariv3dsTEnBaffQAwLPjMdv3jwGXlDCDhwFSPJcUoSR/HdUywOTPBMsBkuSRjxHwQtaGtvV90IeC6lM6zgUkclwv2cRz1YQXfmXTQqRwFrnoCj44/QdbK6nEpx5yDZSnHiYmrwyKzhGcbqBYNd3ses4T7gG2kYBkFm247ANXS8WCBL+SrM0ScXVT/4si4z3Hce/jBWCTDxkikQuWbJREdOHb4v5zfR6BeYtZyoRWG/pu2qcVjUYERSoharTV3cXBUTdPWX3MfL1uqyr6w2JgwkhTXk28BhVzNRnQiuKfJexEz8LG6KAlqUODaOTidRYyHuUBintYHdNvMaqMJ4qLGEkDjzJRZoAAOTeKI5nGYsET+QZAPIhyfUGKGZnHkOjtcV8Nb2++5DYhrAxGeEe8fyGMSuUd5RpZFZV+B3GLExVPVWRFtoHH1Zdb/h/1Xj9oe6E36e6E25/rFVDlX9g4oYtFRF4Q3DPJR7kOpgjO107cxnibydL1LxXttq6yrPSSPEFRXo2RWomxfNl4sB5N5vA4euYJ1GNdjl/bNOoX6m2vMmbvEllgUJGb56GNJdQTB33bLIApm7BPzKRbMQx5tHV5P7mFg79XDMQUOQ8ZPFxz1CwZXHOK8smZoejsZSXSPtSPdVTaNQnWk9aR5/pyXMp7g1GX6umoW2OKRk4VpFglO/Tv6Gs9lcfBTB22nGJrUkebZtgM9wzsS4kFKHGxuzRwqISSnWRNpNGThQuUk1LS7xn4n0jzjOG9Xpk1uN6Nr8NaVLLmdaWah678OSp/njK6dfOOjEZWuVPRubDQ8YdddCuYCi5NHAHrc9vm39LT9u/Cbq/ebHOi2zLNjw8cLlPI8g1ebhbTH+jsixfAao5cd4=
+
+Check out [NodeShare.io](https://nodeshare.io/) by @nodeshareio, a website for sharing materials with Node Sharer!
 
 Join the [Discord](https://discord.gg/c9fZKRb) if you have comments, or want to share materials with people!
 

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@ SOFTWARE.
 bl_info = {
     "name": "Node Sharer",
     "author": "NodeSharer Devs",
-    "version": (0, 1, 5),
+    "version": (0, 2, 0),
     "blender": (2, 90, 0),
     "location": "Node Editor Toolbar",
     "description": "Share node setups as text strings.",

--- a/compfixer.py
+++ b/compfixer.py
@@ -1,0 +1,98 @@
+"""
+MIT License
+
+Copyright (c) 2020 Node Sharer Devs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+import pprint
+import bpy
+
+
+def upgrade_to_blender2910(nodes):
+    """
+    Blender 2.91 adds a new input to the BSDF node, emit strength in slot 18, moving the previous slot 18 up etc.
+    Anything that connect to slot 18 or above from before 2.91 will have it's slot number increased by one.
+    The input default values will also be updated to match
+    :param nodes: node tree as dict, nodes or groups
+    """
+    _BSDF_node_names = []
+    print('Upgrading nodes to Blender 2.91...')
+    for n in nodes:
+        node = nodes[n]
+
+        if node['bl_idname'] == 'ShaderNodeBsdfPrincipled':
+            # Save the node name for so connections can be updated
+            _BSDF_node_names.append(node['name'])
+
+            # Shift the input default values slots up
+            for i in reversed(range(18, 22 + 1)):
+                nodes[n]['inputs'][str(i)] = node['inputs'][str(i-1)]
+            del nodes[n]['inputs']['18']
+
+    for n in nodes:
+        node = nodes[n]
+        try:
+            for output, targets in node['outputs'].items():
+                for name, ids in targets.items():
+                    if name in _BSDF_node_names:
+                        # increment if the slot is 18 or higher
+                        if isinstance(ids, int) and ids >= 18:
+                            nodes[n]['outputs'][output][name] = ids + 1
+                        elif isinstance(ids, list):
+                            tmp_ids = ids.copy()
+                            for pos, i in enumerate(ids):
+                                if i >= 18:
+                                    tmp_ids[pos] = i + 1
+                            nodes[n]['outputs'][output][name] = tmp_ids
+
+        except KeyError:
+            print('No outputs in node: {}'.format(node['name']))
+
+    print('Upgrade to Blender 2.91 Complete!')
+    # print('Made it past the second loop. Changed dict:')
+    # pprint.pprint(nodes)
+
+
+def version_difference(prefix):
+    """
+    Not used atm
+    :param prefix:
+    :return:
+    """
+    bv = bpy.app.version
+    blender_version = int(str(bv[0]) + str(bv[1]) + str(bv[2]))
+
+    ns_bv = int(prefix.split('B')[1])
+    if ns_bv != blender_version:
+        return True
+    else:
+        return False
+
+
+def fix(prefix, nodes):
+    """
+    Fix compatibility
+    :param prefix: Node Sharer prefix
+    :param nodes: Node Sharer node dict
+    """
+    bv = bpy.app.version
+    if bv >= (2, 91, 0):
+        if int(prefix.split('B')[1]) < 2910:
+            upgrade_to_blender2910(nodes)

--- a/nodesharer.py
+++ b/nodesharer.py
@@ -22,17 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-bl_info = {
-    "name": "Node Sharer",
-    "author": "NodeSharer Devs",
-    "version": (0, 1, 5),
-    "blender": (2, 90, 0),
-    "location": "Node Editor Toolbar",
-    "description": "Share node setups as text strings.",
-    "warning": "Blender can crash when pasting node groups. Save your work before pasting.",
-    "category": "Node",
-    "tracker_url": "https://github.com/wildiness/NodeSharer#supporthelp-and-bug-reports",
-}  # outdated? remove?
 
 import bpy
 import pprint

--- a/nodesharer.py
+++ b/nodesharer.py
@@ -40,6 +40,7 @@ import json
 import inspect
 import zlib
 import base64
+from . import compfixer
 
 
 def dump(obj):
@@ -373,6 +374,9 @@ class NS_mat_constructor(NS_nodetree):
         self.uncompressed = self.uncompress(b64_string.split('!')[1])
         # ns_ = Node Sharer
         self.ns_nodes = self.uncompressed['nodes']
+
+        compfixer.fix(self.prefix, self.ns_nodes)  # Fix compatability
+
         self.ns_mat_name = self.uncompressed['name']
         self.ns_groups = self.uncompressed.pop('groups', None)
 

--- a/nodesharer.py
+++ b/nodesharer.py
@@ -663,7 +663,7 @@ def unregister():
     bpy.utils.unregister_class(OBJECT_MT_ns_copy_material)
     bpy.utils.unregister_class(OBJECT_MT_ns_paste_material)
     bpy.types.NODE_MT_node.remove(menu_func)
-    print("unregistered OBJECT_MT_ns_copy_material")
+    print("unregistered Add-on: Node Sharer")
 
 
 # This allows you to run the script directly from Blender's Text editor


### PR DESCRIPTION
- Adds support for handling the new "Emission strength" node on the BSDF introduced with blender 2.91. Materials copied with Node Sharer in Blender version lower than 2.91 can be used in 2.91 (and later) and vice versa.
- Updates readme to link to nodeshare.io
- small update in nodeshare.py, removes redundant bl_info and makes the unregistering print the addon name
- Version Bump to 0.2.0