### PR TITLE
Add support for pasteing older materials into Blender 3.0

### DIFF
--- a/nodesharer.py
+++ b/nodesharer.py
@@ -825,7 +825,7 @@ class CompFixer:
             if 2800 < int(prefix.split('B')[1]) < 2910:
                 CompFixer.upgrade_to_blender2910(nodes)
         if bv >= (3, 0, 0):
-            if int(prefix.split('B')[1]) < 3000:
+            if 2800 < int(prefix.split('B')[1]) < 3000:
                 CompFixer.upgrade_to_blender3000(nodes)
         elif bv < (2, 91, 0):
             if int(prefix.split('B')[1]) >= 2910:


### PR DESCRIPTION
Blender 3.0 adds two new inputs to the principled BSDF for the "random walk" Subsurface method. Random walk is also the new default(old was Christensen-Burley, old materials will have this method selected.). These are not mentioned in the changelog as far as I can tell. At the moment it only support upgrading old materials to Blender 3.0. Pasteing materials from Blender 3.0 in a lower Blender version won't work.

Hopefully everything is correct this time.